### PR TITLE
SEO audit: entity schema, social cards, related posts

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -157,6 +157,20 @@ export default function (eleventyConfig) {
     }).toISO();
   });
 
+  // Reading time from the rendered post. Prose runs at 220 wpm. Code blocks are
+  // pulled out of the word count first, because tokenising source as prose
+  // wildly overcounts, and charged a flat 15 seconds each instead.
+  eleventyConfig.addFilter("readingTime", (html) => {
+    const source = String(html || "");
+    const codeBlocks = (source.match(/<pre[\s\S]*?<\/pre>/g) || []).length;
+    const prose = source
+      .replace(/<pre[\s\S]*?<\/pre>/g, " ")
+      .replace(/<[^>]+>/g, " ")
+      .replace(/&[a-z#0-9]+;/gi, " ");
+    const words = prose.split(/\s+/).filter(Boolean).length;
+    return Math.max(1, Math.round(words / 220 + codeBlocks * 0.25));
+  });
+
   // Related posts.
   //
   // Scored from URL slugs rather than titles: slugs are already lowercased and

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -157,6 +157,31 @@ export default function (eleventyConfig) {
     }).toISO();
   });
 
+  // JSON.stringify for template use. Liquid has no autoescape and no json
+  // filter, so any text interpolated into JSON-LD must go through this or a
+  // stray quote breaks the block. Emits the surrounding quotes itself.
+  eleventyConfig.addFilter("jsonify", (value) => {
+    return JSON.stringify(value === undefined || value === null ? "" : value);
+  });
+
+  // "September 14-15, 2026" -> { start: "2026-09-14", end: "2026-09-15" }
+  const MONTHS = ["january","february","march","april","may","june","july",
+    "august","september","october","november","december"];
+  function parseSessionDate(str) {
+    const match = String(str || "").match(/^(\w+)\s+(\d{1,2})(?:\s*-\s*(\d{1,2}))?,\s*(\d{4})$/);
+    if (!match) return null;
+    const month = MONTHS.indexOf(match[1].toLowerCase());
+    if (month < 0) return null;
+    const pad = (n) => String(n).padStart(2, "0");
+    const year = match[4];
+    return {
+      start: `${year}-${pad(month + 1)}-${pad(match[2])}`,
+      end: `${year}-${pad(month + 1)}-${pad(match[3] || match[2])}`,
+    };
+  }
+  eleventyConfig.addFilter("sessionStart", (str) => (parseSessionDate(str) || {}).start || "");
+  eleventyConfig.addFilter("sessionEnd", (str) => (parseSessionDate(str) || {}).end || "");
+
   // "5h 59m" -> "PT5H59M" for schema.org durations
   eleventyConfig.addFilter("isoDuration", (str) => {
     if (!str) return "";

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -157,6 +157,17 @@ export default function (eleventyConfig) {
     }).toISO();
   });
 
+  // "5h 59m" -> "PT5H59M" for schema.org durations
+  eleventyConfig.addFilter("isoDuration", (str) => {
+    if (!str) return "";
+    const match = String(str).match(/(?:(\d+)\s*h)?\s*(?:(\d+)\s*m)?/i);
+    if (!match) return "";
+    const hours = parseInt(match[1] || 0, 10);
+    const minutes = parseInt(match[2] || 0, 10);
+    if (!hours && !minutes) return "";
+    return `PT${hours ? hours + "H" : ""}${minutes ? minutes + "M" : ""}`;
+  });
+
   // String helpers
   eleventyConfig.addFilter("lower", (str) => {
     return str ? str.toLowerCase() : "";

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -157,6 +157,108 @@ export default function (eleventyConfig) {
     }).toISO();
   });
 
+  // Related posts.
+  //
+  // Scored from URL slugs rather than titles: slugs are already lowercased and
+  // hyphenated, so ".NET" and "C#" arrive as "dotnet" and "csharp" instead of
+  // punctuation that has to be special-cased. Shared tokens are weighted by
+  // inverse document frequency, so "hexagonal" (3 posts) counts for far more
+  // than "dotnet" (dozens). A matching category adds a bonus, and a small
+  // recency term breaks ties toward posts that can still rank.
+  //
+  // A `related` front matter list of slugs overrides the scoring entirely.
+  // Generic headline vocabulary. IDF cannot separate these from topic words in
+  // a corpus this small: "know" appears in three slugs, so it scores as highly
+  // as a genuinely rare technical term and pairs a TDD post with one about
+  // React rendering. Topic words have to carry the match on their own.
+  const RELATED_STOPWORDS = new Set([
+    "the","and","for","with","your","you","that","this","how","why","what","who",
+    "when","where","not","dont","from","are","was","were","its","has","have","had",
+    "can","will","should","does","did","but","all","any","get","got","make","makes",
+    "use","uses","using","new","one","two","three","into","out","about","more",
+    "most","just","than","then","too","very","their","them","they","our","been",
+    "because","which","know","knows","knowing","known","awesome","feature",
+    "features","secret","secrets","powerful","small","perfect","best","better",
+    "good","great","things","thing","need","needs","simple","simply","easy","hard",
+    "quick","fast","slow","first","last","next","every","only","still","always",
+    "never","really","actually","want","wants","like","love","think","thoughts",
+    "tips","tip","guide","way","ways","look","looking","start","starting","stop",
+    "keep","take","takes","put","give","gives","going","own","off","over","under",
+    "again","once","here","there","now","today","everything","anything","something",
+    "people","someone","yourself","myself","much","many","few","less","lot","lots",
+    "why","let","lets","made","made","must","may","might","see","saw","seen",
+  ]);
+
+  // Crude suffix stemmer. Enough to collapse test / tests / testing and
+  // refactoring / refactorings onto a shared stem, which is where most of the
+  // missed matches were.
+  function stem(token) {
+    if (token.length > 5 && token.endsWith("ings")) return token.slice(0, -4);
+    if (token.length > 4 && token.endsWith("ing")) return token.slice(0, -3);
+    if (token.length > 4 && token.endsWith("ies")) return token.slice(0, -3) + "y";
+    if (token.length > 4 && token.endsWith("es")) return token.slice(0, -2);
+    if (token.length > 3 && token.endsWith("s")) return token.slice(0, -1);
+    return token;
+  }
+
+  function slugTokens(url) {
+    const parts = String(url || "").split("/").filter(Boolean).pop().split("-");
+    const kept = parts.filter((part, index) => {
+      // A leading number is a listicle count ("3-tdd-techniques"). A number
+      // anywhere else is usually a version ("csharp-11-required-members"),
+      // which is one of the strongest signals in these slugs.
+      if (/^\d+$/.test(part)) return index > 0;
+      return part.length > 2 && !RELATED_STOPWORDS.has(part);
+    });
+    return new Set(kept.map(stem));
+  }
+
+  eleventyConfig.addFilter("relatedPosts", function (posts, currentUrl, currentCategory, explicit, limit) {
+    const max = limit || 3;
+    const pool = (posts || []).filter((p) => p.url !== currentUrl);
+
+    // Explicit override wins. Match on the slug at the end of the URL.
+    if (Array.isArray(explicit) && explicit.length) {
+      const wanted = explicit.map((s) => String(s).replace(/^\/|\/$/g, "").split("/").pop());
+      const picked = wanted
+        .map((slug) => pool.find((p) => p.url.replace(/\/$/, "").split("/").pop() === slug))
+        .filter(Boolean);
+      if (picked.length) return picked.slice(0, max);
+    }
+
+    // Document frequency across the whole pool, for IDF weighting.
+    const df = new Map();
+    pool.forEach((p) => slugTokens(p.url).forEach((t) => df.set(t, (df.get(t) || 0) + 1)));
+
+    const mine = slugTokens(currentUrl);
+
+    const scored = pool.map((p) => {
+      let topical = 0;
+      slugTokens(p.url).forEach((t) => {
+        if (mine.has(t)) topical += 1 / Math.sqrt(df.get(t) || 1);
+      });
+      // Category is deliberately not scored. The existing values are
+      // inconsistent and several are catch-alls: "Improvement" alone spans
+      // refactoring, team management and behavioural science, and matching on
+      // it pairs posts that have nothing to do with each other. Slug overlap
+      // on its own produces tighter clusters.
+
+      // Recency is a tie-breaker among genuinely related posts, never a score
+      // of its own. Without this guard a post with no topical match just gets
+      // "the three newest posts", which is not a relationship and funnels every
+      // link on the site into a handful of URLs.
+      if (topical < 0.3) return null;
+
+      const year = p.date ? p.date.getUTCFullYear() : 2014;
+      return { post: p, score: topical + Math.max(0, year - 2014) * 0.015 };
+    }).filter(Boolean);
+
+    return scored
+      .sort((a, b) => b.score - a.score)
+      .slice(0, max)
+      .map((x) => x.post);
+  });
+
   // JSON.stringify for template use. Liquid has no autoescape and no json
   // filter, so any text interpolated into JSON-LD must go through this or a
   // stray quote breaks the block. Emits the surrounding quotes itself.

--- a/src/_includes/components/blog-list.njk
+++ b/src/_includes/components/blog-list.njk
@@ -13,9 +13,7 @@
                                     <span class="text-gray-400 dark:text-gray-500 transition-colors" aria-hidden="true">•</span>
                                 {% endif %}
                                 <time datetime="{{ post.date | htmlDate }}" class="text-gray-500 dark:text-gray-400">{{ post.date | readableDate }}</time>
-                                {% if post.data.readingTime %}
-                                    <span class="text-gray-500 dark:text-gray-400" aria-hidden="true">• {{ post.data.readingTime }} min read</span>
-                                {% endif %}
+                                <span class="text-gray-500 dark:text-gray-400">&bull; {{ post.templateContent | readingTime }} min read</span>
                             </div>
                             <h3 class="text-2xl font-medium text-gray-900 dark:text-white leading-tight">
                                 <a href="{{ post.url }}" class="hover:underline" aria-label="Read post: {{ post.data.title }}">{{ post.data.title }}</a>

--- a/src/_includes/components/entity-schema.liquid
+++ b/src/_includes/components/entity-schema.liquid
@@ -1,8 +1,11 @@
 {%- comment -%}
-  Site-wide entity graph. Included on the homepage and the about page only.
+  Site-wide entity graph, emitted on every page from default.liquid.
   The bio is the official one and is kept verbatim in sync with
   src/about.liquid, src/for-llms.liquid and src/llms.txt.
 {%- endcomment -%}
+{%- assign pgTitle = title | default: site.title -%}
+{%- assign pgDescription = description | default: site.description -%}
+{%- assign pgUrl = site.url | append: page.url -%}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -57,11 +60,21 @@
       "@type": "WebSite",
       "@id": "{{ site.url }}/#website",
       "url": "{{ site.url }}/",
-      "name": "{{ site.title }}",
-      "description": "{{ site.description }}",
+      "name": {{ site.title | jsonify }},
+      "description": {{ site.description | jsonify }},
       "inLanguage": "en",
       "publisher": { "@id": "{{ site.url }}/#person" },
       "author": { "@id": "{{ site.url }}/#person" }
+    },
+    {
+      "@type": "WebPage",
+      "@id": "{{ pgUrl }}",
+      "url": "{{ pgUrl }}",
+      "name": {{ pgTitle | jsonify }},
+      "description": {{ pgDescription | jsonify }},
+      "isPartOf": { "@id": "{{ site.url }}/#website" },
+      "about": { "@id": "{{ site.url }}/#person" },
+      "inLanguage": "en"
     }
   ]
 }

--- a/src/_includes/components/entity-schema.liquid
+++ b/src/_includes/components/entity-schema.liquid
@@ -1,0 +1,68 @@
+{%- comment -%}
+  Site-wide entity graph. Included on the homepage and the about page only.
+  The bio is the official one and is kept verbatim in sync with
+  src/about.liquid, src/for-llms.liquid and src/llms.txt.
+{%- endcomment -%}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Person",
+      "@id": "{{ site.url }}/#person",
+      "name": "Gui Ferreira",
+      "givenName": "Guilherme",
+      "familyName": "Ferreira",
+      "alternateName": "Guilherme Ferreira",
+      "description": "Guilherme \"Gui\" Ferreira is a Microsoft MVP and the founder of Black Lab Studios. After 20 years building software, he now spends most of his time teaching it, through Dometrain courses, hands-on workshops, and a YouTube channel. His filter for everything is simplicity: the few moves that actually matter.",
+      "url": "{{ site.url }}/about/",
+      "mainEntityOfPage": "{{ site.url }}/about/",
+      "image": {
+        "@type": "ImageObject",
+        "url": "{{ site.url }}/assets/headshot-1024x1024.png",
+        "width": 1024,
+        "height": 1024
+      },
+      "jobTitle": [
+        "Software Engineer Educator",
+        "Course Author",
+        "Workshop Facilitator",
+        "Speaker"
+      ],
+      "award": "Microsoft MVP",
+      "knowsAbout": [
+        ".NET",
+        "C#",
+        "Clean Code",
+        "Software Testing",
+        "Test-Driven Development",
+        "Software Architecture",
+        "xUnit",
+        "OpenTelemetry"
+      ],
+      "worksFor": {
+        "@type": "Organization",
+        "name": "Black Lab Studios",
+        "url": "https://blacklabstudios.com",
+        "founder": { "@id": "{{ site.url }}/#person" }
+      },
+      "sameAs": [
+        "https://twitter.com/gsferreira",
+        "https://www.linkedin.com/in/gferreira",
+        "https://github.com/gsferreira",
+        "https://www.youtube.com/@gui.ferreira"
+      ]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "{{ site.url }}/#website",
+      "url": "{{ site.url }}/",
+      "name": "{{ site.title }}",
+      "description": "{{ site.description }}",
+      "inLanguage": "en",
+      "publisher": { "@id": "{{ site.url }}/#person" },
+      "author": { "@id": "{{ site.url }}/#person" }
+    }
+  ]
+}
+</script>

--- a/src/_includes/components/related-posts.njk
+++ b/src/_includes/components/related-posts.njk
@@ -1,0 +1,33 @@
+{#
+  Related posts. Scoring lives in the relatedPosts filter in eleventy.config.js.
+  A `related` front matter list of slugs on the post overrides it.
+#}
+{% set relatedList = collections.post | relatedPosts(page.url, category, related, 3) %}
+{% if relatedList.length %}
+<aside class="max-w-3xl mx-auto px-4 mt-28" aria-labelledby="related-heading">
+  <h2 id="related-heading" class="text-xs uppercase tracking-[0.14em] font-medium text-gray-500 dark:text-gray-400 pb-4 border-b border-gray-200 dark:border-gray-800">
+    Keep reading
+  </h2>
+  <ul class="divide-y divide-gray-100 dark:divide-gray-800" role="list">
+    {% for item in relatedList %}
+    <li>
+      <article class="py-7">
+        <div class="flex items-center gap-3 text-[13px] mb-2">
+          {% if item.data.category %}
+          <span class="uppercase font-medium text-gray-500 dark:text-gray-400">{{ item.data.category }}</span>
+          <span class="text-gray-300 dark:text-gray-600" aria-hidden="true">&bull;</span>
+          {% endif %}
+          <time datetime="{{ item.date | htmlDate }}" class="text-gray-500 dark:text-gray-400">{{ item.date | readableDate }}</time>
+        </div>
+        <h3 class="text-xl font-medium text-gray-900 dark:text-white leading-snug mb-2">
+          <a href="{{ item.url }}" class="hover:underline">{{ item.data.title }}</a>
+        </h3>
+        {% if item.data.description %}
+        <p class="text-gray-500 dark:text-gray-400 text-[15px] leading-relaxed">{{ item.data.description }}</p>
+        {% endif %}
+      </article>
+    </li>
+    {% endfor %}
+  </ul>
+</aside>
+{% endif %}

--- a/src/_includes/layouts/course.njk
+++ b/src/_includes/layouts/course.njk
@@ -167,31 +167,63 @@ layout: default
   {
     "@context": "https://schema.org",
     "@type": "VideoObject",
-    "name": "{{ heroVideo.title or title }} - Course Preview",
-    "description": "{{ heroVideo.description or description }}",
-    "thumbnailUrl": "{{ heroVideo.poster.png or heroVideo.poster }}",
+    "name": {{ ((heroVideo.title or title) + " - Course Preview") | dump | safe }},
+    "description": {{ (heroVideo.description or description) | dump | safe }},
+    "thumbnailUrl": "{{ site.url }}{{ heroVideo.poster.png or heroVideo.poster }}",
     "uploadDate": "{{ heroVideo.uploadDate or page.date | isoDate }}",
     "duration": "{{ heroVideo.duration or 'PT30S' }}",
-    "contentUrl": "{{ heroVideo.mp4 }}",
+    "contentUrl": "{{ site.url }}{{ heroVideo.mp4 }}",
     "embedUrl": "{{ site.url }}{{ page.url }}",
     "publisher": {
-      "@type": "Organization",
-      "name": "{{ site.title }}",
-      "url": "{{ site.url }}"
+      "@type": "Person",
+      "@id": "{{ site.url }}/#person",
+      "name": "Gui Ferreira",
+      "url": "{{ site.url }}/about/"
     },
-    "isPartOf": {
-      "@type": "Course",
-      "name": "{{ title }}",
-      "description": "{{ description }}",
-      "provider": {
-        "@type": "Organization",
-        "name": "{{ site.title }}"
-      }
-    }
+    "isPartOf": { "@id": "{{ site.url }}{{ page.url }}#course" }
   }
   </script>
   {% endif %}
   {% endif %}
+
+  {# Course schema is emitted for every course, with or without a preview video. #}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Course",
+    "@id": "{{ site.url }}{{ page.url }}#course",
+    "name": {{ title | dump | safe }},
+    "description": {{ description | dump | safe }},
+    "url": "{{ site.url }}{{ page.url }}",
+    "inLanguage": "en",
+    {% if image %}"image": "{{ site.url }}{{ image }}",
+    {% endif %}{% if level %}"educationalLevel": {{ level | dump | safe }},
+    {% endif %}{% if category %}"about": {{ category | dump | safe }},
+    {% endif %}"provider": {
+      "@type": "Person",
+      "@id": "{{ site.url }}/#person",
+      "name": "Gui Ferreira",
+      "url": "{{ site.url }}/about/"
+    },
+    "author": {
+      "@type": "Person",
+      "@id": "{{ site.url }}/#person",
+      "name": "Gui Ferreira",
+      "url": "{{ site.url }}/about/"
+    },
+    "hasCourseInstance": {
+      "@type": "CourseInstance",
+      "courseMode": "online",
+      {% if duration %}"courseWorkload": "{{ duration | isoDuration }}",
+      {% endif %}"instructor": {
+        "@type": "Person",
+        "@id": "{{ site.url }}/#person",
+        "name": "Gui Ferreira",
+        "url": "{{ site.url }}/about/"
+      }
+    }
+  }
+  </script>
 
   <div class="prose dark:prose-invert dark:text-gray-200 prose-headings:dark:text-white prose-strong:dark:text-white prose-ul:dark:text-gray-200 max-w-none">
     {{ content | safe }}

--- a/src/_includes/layouts/default.liquid
+++ b/src/_includes/layouts/default.liquid
@@ -58,6 +58,8 @@
     <meta name="twitter:description" content="{{ metaDescription | escape }}">
     <meta name="twitter:image" content="{{ metaImage }}">
 
+    {% include 'components/entity-schema.liquid' %}
+
     <link rel="shortcut icon" href="/images/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png">

--- a/src/_includes/layouts/default.liquid
+++ b/src/_includes/layouts/default.liquid
@@ -4,6 +4,16 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover" />
     {%- assign metaTitle = title | default: site.title -%}
+    {%- comment -%}
+      Brand suffix, but only where it fits. Appending to an already-long title
+      just moves the truncation point and the brand gets cut anyway.
+    {%- endcomment -%}
+    {%- assign titleLength = metaTitle | size -%}
+    {%- if page.url == "/" or metaTitle contains "Gui Ferreira" or titleLength > 45 -%}
+      {%- assign documentTitle = metaTitle -%}
+    {%- else -%}
+      {%- assign documentTitle = metaTitle | append: " | Gui Ferreira" -%}
+    {%- endif -%}
     {%- assign metaDescription = description | default: site.description -%}
     {%- assign metaUrl = site.url | append: page.url -%}
     {%- if socialImage -%}
@@ -24,7 +34,7 @@
     <base href="{{ page.url }}">
     <link rel="canonical" href="{{ metaUrl }}">
 
-    <title>{{ metaTitle | escape }}</title>
+    <title>{{ documentTitle | escape }}</title>
 
     <!-- Open Graph -->
     <meta property="og:type" content="{{ metaType }}">

--- a/src/_includes/layouts/default.liquid
+++ b/src/_includes/layouts/default.liquid
@@ -3,12 +3,50 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover" />
-    <meta name="description" content="{% if description %}{{ description }}{% else %}Your site description{% endif %}" />
+    {%- assign metaTitle = title | default: site.title -%}
+    {%- assign metaDescription = description | default: site.description -%}
+    {%- assign metaUrl = site.url | append: page.url -%}
+    {%- if socialImage -%}
+      {%- assign metaImage = site.url | append: socialImage -%}
+    {%- else -%}
+      {%- assign metaImage = site.url | append: "/assets/headshot-1024x1024.png" -%}
+    {%- endif -%}
+    {%- if ogType -%}
+      {%- assign metaType = ogType -%}
+    {%- elsif page.url contains "/archive/" -%}
+      {%- assign metaType = "article" -%}
+    {%- else -%}
+      {%- assign metaType = "website" -%}
+    {%- endif -%}
+
+    <meta name="description" content="{{ metaDescription | escape }}" />
     <meta name="generator" content="{{ eleventy.generator }}">
     <base href="{{ page.url }}">
-    <link rel="canonical" href="{{ site.url }}{{ page.url }}">
+    <link rel="canonical" href="{{ metaUrl }}">
 
-    <title>{% if title %}{{ title }}{% else %}Your site title{% endif %}</title>
+    <title>{{ metaTitle | escape }}</title>
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="{{ metaType }}">
+    <meta property="og:site_name" content="{{ site.title | escape }}">
+    <meta property="og:title" content="{{ metaTitle | escape }}">
+    <meta property="og:description" content="{{ metaDescription | escape }}">
+    <meta property="og:url" content="{{ metaUrl }}">
+    <meta property="og:image" content="{{ metaImage }}">
+    <meta property="og:image:alt" content="Gui Ferreira, software engineer educator, speaker and Microsoft MVP">
+    <meta property="og:locale" content="en_US">
+    {%- if metaType == "article" %}
+    <meta property="article:published_time" content="{{ page.date | isoDate }}">
+    <meta property="article:author" content="{{ site.url }}/about/">
+    {%- endif %}
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="@gsferreira">
+    <meta name="twitter:creator" content="@gsferreira">
+    <meta name="twitter:title" content="{{ metaTitle | escape }}">
+    <meta name="twitter:description" content="{{ metaDescription | escape }}">
+    <meta name="twitter:image" content="{{ metaImage }}">
 
     <link rel="shortcut icon" href="/images/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -57,7 +57,7 @@ layout: default
         {% endif %}
 
         <div class="text-[15px] text-gray-500 dark:text-gray-400">
-          <time datetime="{{ page.date | htmlDate }}">{{ page.date | readableDate }}</time> · <span aria-hidden="true">7 min read</span>
+          <time datetime="{{ page.date | htmlDate }}">{{ page.date | readableDate }}</time> · <span>{{ content | readingTime }} min read</span>
         </div>
       </div>
 

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -68,6 +68,8 @@ layout: default
   </article>
 </div>
 
+{% include "components/related-posts.njk" %}
+
 <div class="mt-32">
   {% include "components/newsletter.liquid" %}
 </div> 

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -6,32 +6,36 @@ layout: default
 {
   "@context": "https://schema.org",
   "@type": "Article",
-  "headline": "{{ title }}",
-  "description": "{{ description }}",
+  "headline": {{ title | dump | safe }},
+  "description": {{ description | dump | safe }},
+  "image": "{{ site.url }}{{ image or '/assets/headshot-1024x1024.png' }}",
   "datePublished": "{{ page.date | htmlDate }}",
-  "dateModified": "{{ page.date | htmlDate }}",
+  "dateModified": "{{ (updated or page.date) | htmlDate }}",
+  "inLanguage": "en",
   "author": {
     "@type": "Person",
+    "@id": "{{ site.url }}/#person",
     "name": "Gui Ferreira",
     "givenName": "Guilherme",
     "familyName": "Ferreira",
     "alternateName": "Guilherme Ferreira",
-    "url": "https://guiferreira.me/about",
+    "url": "{{ site.url }}/about/",
     "sameAs": [
       "https://twitter.com/gsferreira",
-      "https://linkedin.com/in/gferreira",
+      "https://www.linkedin.com/in/gferreira",
       "https://github.com/gsferreira",
-      "https://youtube.com/@gui.ferreira"
+      "https://www.youtube.com/@gui.ferreira"
     ]
   },
   "publisher": {
     "@type": "Person",
+    "@id": "{{ site.url }}/#person",
     "name": "Gui Ferreira",
-    "url": "https://guiferreira.me"
+    "url": "{{ site.url }}"
   },
   "mainEntityOfPage": {
     "@type": "WebPage",
-    "@id": "https://guiferreira.me{{ page.url }}"
+    "@id": "{{ site.url }}{{ page.url }}"
   }
 }
 </script>

--- a/src/about.liquid
+++ b/src/about.liquid
@@ -4,7 +4,6 @@ title: About Gui Ferreira
 description: Learn more about Gui Ferreira, a software engineer educator, speaker, and Microsoft MVP.
 ---
 
-{% include 'components/entity-schema.liquid' %}
 <!-- Hero Section -->
 <section class="max-w-4xl mx-auto px-6 pt-20 pb-16">
   <div class="grid md:grid-cols-2 gap-12 items-center">

--- a/src/about.liquid
+++ b/src/about.liquid
@@ -4,6 +4,7 @@ title: About Gui Ferreira
 description: Learn more about Gui Ferreira, a software engineer educator, speaker, and Microsoft MVP.
 ---
 
+{% include 'components/entity-schema.liquid' %}
 <!-- Hero Section -->
 <section class="max-w-4xl mx-auto px-6 pt-20 pb-16">
   <div class="grid md:grid-cols-2 gap-12 items-center">

--- a/src/archive/2023/3-tdd-techniques-most-people-dont-know/index.md
+++ b/src/archive/2023/3-tdd-techniques-most-people-dont-know/index.md
@@ -5,6 +5,11 @@ date: 2023-03-31
 title: 3 TDD Techniques Most People Don’t Know
 description: Master 3 TDD techniques most developers ignore - Fake It, Obvious Implementation, and Triangulation for effective test-driven development.
 featured_image: /images/archive/highlight/3-tdd-techniques.png
+# TDD is the only slug on the site using that abbreviation, so scoring finds nothing. Its real siblings all say tests or testing.
+related:
+  - why-i-dont-use-loops-on-my-tests
+  - how-structure-sensitive-tests-make-refactorings-fail
+  - my-simple-testing-stack-for-dotnet-developers-2023
 ---
 
 https://www.youtube.com/watch?v=ga6i2i_ynYE

--- a/src/archive/2023/a-better-way-to-kafka-event-driven-applications-with-csharp/index.md
+++ b/src/archive/2023/a-better-way-to-kafka-event-driven-applications-with-csharp/index.md
@@ -5,6 +5,9 @@ date: 2023-12-13
 title: A BETTER Way to Kafka Event-Driven Applications with C#
 description: Build better C# Kafka event-driven applications with KafkaFlow - simplified patterns, middleware, and maintainable architecture.
 featured_image: /images/archive/highlight/a-better-way-to-kafka-event-driven-applications-with-csharp.png
+# kafka and kafkaflow stem differently, so the pair has to be stated.
+related:
+  - 3-kafkaflow-features-hard-to-ignore
 ---
 
 https://youtu.be/4e18DZkf-m0?si=QMgwWgQFKFZqRbD3

--- a/src/blog.njk
+++ b/src/blog.njk
@@ -33,8 +33,8 @@ eleventyNavigation:
 
 
 <div class="max-w-6xl mx-auto text-center py-16">
-  <h1 class="text-4xl [font-size:2.25rem] font-light mb-2 text-gray-900 dark:text-white">Insights</h1>
-  <p class="text-lg text-gray-500 dark:text-gray-400 mb-8">Thoughts on innovation, design, leadership, and building products that change the world.</p>
+  <h1 class="text-4xl [font-size:2.25rem] font-light mb-2 text-gray-900 dark:text-white">Notes on .NET, testing, and simpler code</h1>
+  <p class="text-lg text-gray-500 dark:text-gray-400 mb-8">Everything here comes from something I've built or broken. Mostly C# and .NET, mostly about testing, architecture, and cutting what you don't need.</p>
 </div>
 
 {% set featured = collections.post | selectattr('data.featured', 'equalto', true) | first %}

--- a/src/blog.njk
+++ b/src/blog.njk
@@ -7,6 +7,30 @@ eleventyNavigation:
   key: Blog
   order: 2
 ---
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Blog",
+  "@id": "{{ site.url }}/blog/#blog",
+  "name": {{ title | dump | safe }},
+  "description": {{ description | dump | safe }},
+  "url": "{{ site.url }}/blog/",
+  "inLanguage": "en",
+  "author": { "@id": "{{ site.url }}/#person" },
+  "publisher": { "@id": "{{ site.url }}/#person" },
+  "blogPost": [
+    {%- for post in collections.post | reverse %}{% if loop.index <= 10 %}{% if loop.index > 1 %},{% endif %}
+    {
+      "@type": "BlogPosting",
+      "headline": {{ post.data.title | dump | safe }},
+      "url": "{{ site.url }}{{ post.url }}",
+      "datePublished": "{{ post.date | htmlDate }}",
+      "author": { "@id": "{{ site.url }}/#person" }
+    }{% endif %}{%- endfor %}
+  ]
+}
+</script>
+
 
 <div class="max-w-6xl mx-auto text-center py-16">
   <h1 class="text-4xl [font-size:2.25rem] font-light mb-2 text-gray-900 dark:text-white">Insights</h1>

--- a/src/courses.liquid
+++ b/src/courses.liquid
@@ -3,6 +3,32 @@ layout: default
 title: Courses by Gui Ferreira
 description: Learn to code like an artist. Ship like a pro.
 ---
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "@id": "{{ site.url }}/courses/#collection",
+  "name": {{ title | jsonify }},
+  "description": {{ description | jsonify }},
+  "url": "{{ site.url }}/courses/",
+  "isPartOf": { "@id": "{{ site.url }}/#website" },
+  "about": { "@id": "{{ site.url }}/#person" },
+  "mainEntity": {
+    "@type": "ItemList",
+    "itemListElement": [
+      {%- for course in collections.courses %}
+      {% unless forloop.first %},{% endunless %}{
+        "@type": "ListItem",
+        "position": {{ forloop.index }},
+        "url": "{{ site.url }}{{ course.url }}",
+        "name": {{ course.data.title | jsonify }}
+      }
+      {%- endfor %}
+    ]
+  }
+}
+</script>
+
 
 <section class="relative bg-white dark:bg-black py-24 lg:py-32 mt-16 transition-colors">
   <div class="container mx-auto px-6 max-w-4xl">

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -3,6 +3,7 @@ layout: default
 title: "Gui Ferreira – Software Engineer Educator, Speaker, Microsoft MVP"
 description: "Courses and workshops to inspire your next breakthrough in software and tech."
 ---
+{% include 'components/entity-schema.liquid' %}
 {% include 'components/hero.liquid' %}
 {% include 'components/about.liquid' %}
 {% include 'components/courses.liquid' %}

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Gui Ferreira – Software Engineer Educator, Mentor, Innovator"
+title: "Gui Ferreira – Software Engineer Educator, Speaker, Microsoft MVP"
 description: "Courses and workshops to inspire your next breakthrough in software and tech."
 ---
 {% include 'components/hero.liquid' %}

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -3,7 +3,6 @@ layout: default
 title: "Gui Ferreira – Software Engineer Educator, Speaker, Microsoft MVP"
 description: "Courses and workshops to inspire your next breakthrough in software and tech."
 ---
-{% include 'components/entity-schema.liquid' %}
 {% include 'components/hero.liquid' %}
 {% include 'components/about.liquid' %}
 {% include 'components/courses.liquid' %}

--- a/src/newsletter.liquid
+++ b/src/newsletter.liquid
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Newsletter
+title: Weekly .NET and Clean Code Newsletter
 description: Subscribe to my newsletter to get weekly insights about .NET, Software Architecture, and Clean Code.
 ---
 

--- a/src/resources/software-testing-roadmap-dotnet.njk
+++ b/src/resources/software-testing-roadmap-dotnet.njk
@@ -1,7 +1,7 @@
 ---
 layout: resource
-title: Newsletter
-description: "Software Testing Roadmap for .NET Developers"
+title: Software Testing Roadmap for .NET Developers
+description: "Follow a step-by-step roadmap to learn software testing as a .NET developer, from the fundamentals to a testing stack you can rely on."
 --- 
 
 <h1>

--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,3 +1,2 @@
-User-agent: * 
-Disallow: /assets/
+User-agent: *
 Sitemap: https://guiferreira.me/sitemap.xml

--- a/src/talks.liquid
+++ b/src/talks.liquid
@@ -3,6 +3,29 @@ layout: default
 title: Talks by Gui Ferreira
 description: Talks I've given. Ideas worth sharing.
 ---
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Talks by Gui Ferreira",
+  "itemListElement": [
+    {%- for talk in talks.all %}
+    {% unless forloop.first %},{% endunless %}{
+      "@type": "ListItem",
+      "position": {{ forloop.index }},
+      "item": {
+        "@type": "CreativeWork",
+        "name": {{ talk.title | jsonify }},
+        "abstract": {{ talk.description | jsonify }},
+        "author": { "@id": "{{ site.url }}/#person" },
+        "inLanguage": "en"
+      }
+    }
+    {%- endfor %}
+  ]
+}
+</script>
+
 
 <div class="max-w-4xl mx-auto px-4 py-16">
     <h1 class="text-4xl [font-size:2.25rem] font-bold text-center mb-4 text-gray-900 dark:text-white">Talks</h1>

--- a/src/workshops.liquid
+++ b/src/workshops.liquid
@@ -3,6 +3,49 @@ layout: default.liquid
 title: Workshops with Gui Ferreira
 description: Where to catch me running a workshop in public, and how to book one for your team. The workshops themselves run through Black Lab Studios.
 ---
+{%- assign availableCount = 0 -%}
+{%- for workshop in workshopDates -%}{%- for session in workshop.sessions -%}{%- if session.available -%}{%- assign availableCount = availableCount | plus: 1 -%}{%- endif -%}{%- endfor -%}{%- endfor -%}
+{%- if availableCount > 0 -%}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Upcoming public workshop sessions with Gui Ferreira",
+  "itemListElement": [
+    {%- assign position = 0 -%}
+    {%- for workshop in workshopDates -%}
+    {%- for session in workshop.sessions -%}
+    {%- if session.available -%}
+    {%- assign position = position | plus: 1 -%}
+    {% if position > 1 %},{% endif %}{
+      "@type": "ListItem",
+      "position": {{ position }},
+      "item": {
+        "@type": "Event",
+        "name": {{ workshop.title | jsonify }},
+        "description": {{ workshop.blurb | jsonify }},
+        "startDate": "{{ session.date | sessionStart }}",
+        "endDate": "{{ session.date | sessionEnd }}",
+        "eventStatus": "https://schema.org/EventScheduled",
+        "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+        "location": {
+          "@type": "Place",
+          "name": {{ session.venue | jsonify }},
+          "address": {{ session.location | jsonify }}
+        },
+        "performer": { "@id": "{{ site.url }}/#person" },
+        "organizer": { "@type": "Organization", "name": {{ session.venue | jsonify }} },
+        "url": {{ session.registrationUrl | jsonify }}
+      }
+    }
+    {%- endif -%}
+    {%- endfor -%}
+    {%- endfor %}
+  ]
+}
+</script>
+{%- endif -%}
+
 
 <main class="min-h-screen bg-white dark:bg-black">
     <section class="relative bg-white dark:bg-black py-24 lg:py-32 mt-16 transition-colors">


### PR DESCRIPTION
Implements 14 of 22 findings from an SEO audit of the site. Nothing critical or high remains open.

Priorities were **newsletter signups** and **personal brand / entity**, so the work is weighted toward machine-readable identity and toward getting people from a post to the list.

## What was wrong

The foundations were already good and mostly untouched here. The domain migration redirects deep URLs one to one, the sitemap exactly matches the build, every image has alt text, and there were no orphans or broken links.

The problems clustered in one place. The homepage and about page carried no structured data at all, no page on the site emitted an Open Graph tag, and `robots.txt` blocked the directory holding the headshot. Together that left search engines and social platforms with almost nothing to work with when deciding what "Gui Ferreira" is.

## Commits

| | |
|---|---|
| `077b60e8` | Social meta tags, unblock `/assets/`, fix title regressions |
| `1aad7a48` | Entity schema, top-level `Course` markup, brand titles |
| `11e124ef` | Structured data on every page |
| `2836864d` | Related posts on every article |
| `525846c7` | Computed reading time, blog index copy |

## Verified against a fresh build

```
pages                            147
missing og / twitter tags          0   (was 147)
pages with no structured data      0   (was 145)
invalid JSON-LD                    0
HTML entities inside JSON-LD       0   (was 21 posts)
Articles missing image             0   (was 127)
og:url != canonical                0
duplicate titles                   0

posts with >1 inbound link        99   (was 11)
most-linked single post           10
```

## Notable decisions

**Categories were deliberately not built.** Finding 05 originally proposed a taxonomy. Tuning the related-posts scorer showed the existing values degrade relevance rather than improve it: matching on the shared category `Improvement` paired a post about boolean flag arguments with one about behavioural science in one-on-ones. Slug overlap alone produces tighter clusters. The 78 uncategorised posts stay that way.

**`/talks/` is not marked up as `Event`.** Every talk on that page has already happened, and `Event` without a full postal address earns Search Console warnings while producing no rich result. It uses `CreativeWork`. `/workshops/` does use `Event`, because those three sessions are genuinely upcoming and bookable.

**Brand suffix on titles is conditional.** ` | Gui Ferreira` is appended only where the result stays under 60 characters. Appending to an already long title just moves the truncation point and cuts the brand anyway. 76 of 147 pages qualified.

**Black Lab Studios is expressed as `worksFor` plus a `founder` back-reference**, so the relationship reads as founder rather than as endorsement. Course publisher identity stays with Gui Ferreira.

## Two follow-ups, not in this PR

The default `og:image` is the square 1024x1024 headshot. It works, but `summary_large_image` crops to 2:1 on X, which cuts a portrait badly. A purpose-built 1200x630 card is the fix.

The homepage title is 65 characters, so "Microsoft MVP" may truncate in some SERPs. It was applied as the decided role line rather than trimmed. Leading with the credential would keep it visible at the same length.

## After merge

Validate the new schema through the Rich Results Test, and request re-crawling of the headshot: `/assets/` was disallowed for a long time, so there is a cached state to unlearn.