### PR TITLE
Give schema datetimes a timezone

### DIFF
--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -9,8 +9,8 @@ layout: default
   "headline": {{ title | dump | safe }},
   "description": {{ description | dump | safe }},
   "image": "{{ site.url }}{{ image or '/assets/headshot-1024x1024.png' }}",
-  "datePublished": "{{ page.date | htmlDate }}",
-  "dateModified": "{{ (updated or page.date) | htmlDate }}",
+  "datePublished": "{{ page.date | isoDate }}",
+  "dateModified": "{{ (updated or page.date) | isoDate }}",
   "inLanguage": "en",
   "author": {
     "@type": "Person",

--- a/src/blog.njk
+++ b/src/blog.njk
@@ -24,7 +24,7 @@ eleventyNavigation:
       "@type": "BlogPosting",
       "headline": {{ post.data.title | dump | safe }},
       "url": "{{ site.url }}{{ post.url }}",
-      "datePublished": "{{ post.date | htmlDate }}",
+      "datePublished": "{{ post.date | isoDate }}",
       "author": { "@id": "{{ site.url }}/#person" }
     }{% endif %}{%- endfor %}
   ]


### PR DESCRIPTION
Follow-up to #52, caught by running the Rich Results Test against production after that merged.

## The problem

Every article page reported four non-critical issues:

```
Invalid datetime value for 'datePublished' (optional)
Datetime property 'datePublished' is missing a timezone (optional)
Invalid datetime value for 'dateModified' (optional)
Datetime property 'dateModified' is missing a timezone (optional)
```

Both properties used the `htmlDate` filter, which emits a bare `2017-09-12`. Schema.org expects ISO 8601. The items still validated, since these are optional-field warnings rather than errors, but the dates were not being parsed.

## The fix

`isoDate` already existed and was already used for `VideoObject.uploadDate`, so this is a one word change in three places: `datePublished` and `dateModified` in `post.njk`, and `datePublished` on the `BlogPosting` entries in `blog.njk`.

```
before   "datePublished": "2017-09-12"
after    "datePublished": "2017-09-12T00:00:00.000Z"
```

The visible `<time datetime="2017-09-12">` attributes deliberately keep `htmlDate`. A date-only value is valid there and reads better in the markup.

## Verified

```
date fields across the build   274
without a timezone               0   (was 274)
invalid JSON-LD                  0
```

## Still open, and deliberately so

The workshop `Event` items report two optional fields missing, `image` and `offers`. `offers` is left out on purpose: pricing lives on the conference sites and is not something this repo can state accurately.