### PR TITLE
Use each post's own image for social cards

### DIFF
--- a/src/_includes/layouts/default.liquid
+++ b/src/_includes/layouts/default.liquid
@@ -16,11 +16,14 @@
     {%- endif -%}
     {%- assign metaDescription = description | default: site.description -%}
     {%- assign metaUrl = site.url | append: page.url -%}
-    {%- if socialImage -%}
-      {%- assign metaImage = site.url | append: socialImage -%}
-    {%- else -%}
-      {%- assign metaImage = site.url | append: "/assets/headshot-1024x1024.png" -%}
-    {%- endif -%}
+    {%- comment -%}
+      socialImage overrides, then the post's own featured_image, then the
+      headshot. This is a filter chain rather than {% if %} on purpose: Liquid
+      treats an empty string as truthy, and one post carries an empty
+      featured_image, so an if would resolve og:image to the site root.
+    {%- endcomment -%}
+    {%- assign resolvedImage = socialImage | default: featured_image | default: "/assets/headshot-1024x1024.png" -%}
+    {%- assign metaImage = site.url | append: resolvedImage -%}
     {%- if ogType -%}
       {%- assign metaType = ogType -%}
     {%- elsif page.url contains "/archive/" -%}

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -8,7 +8,7 @@ layout: default
   "@type": "Article",
   "headline": {{ title | dump | safe }},
   "description": {{ description | dump | safe }},
-  "image": "{{ site.url }}{{ image or '/assets/headshot-1024x1024.png' }}",
+  "image": "{{ site.url }}{{ socialImage or featured_image or '/assets/headshot-1024x1024.png' }}",
   "datePublished": "{{ page.date | isoDate }}",
   "dateModified": "{{ (updated or page.date) | isoDate }}",
   "inLanguage": "en",

--- a/src/archive/2020/09/the-value-of-continuous-refactoring/index.md
+++ b/src/archive/2020/09/the-value-of-continuous-refactoring/index.md
@@ -4,7 +4,6 @@ tags: post
 date: 2020-09-24
 title: Continuous Refactoring - Why Small Code Improvements Beat Big Rewrites 
 description: Make refactoring a continuous practice - TDD cycle integration, daily habits, and avoiding technical debt accumulation.
-featured_image: /images/archive/continous-refactoring.png
 ---
 
 ![Continuous Refactoring](/images/archive/clean-code/continous-refactoring.png)

--- a/src/archive/2022/finding-dotnet-transitive-dependencies-and-tidying-up-your-project/index.md
+++ b/src/archive/2022/finding-dotnet-transitive-dependencies-and-tidying-up-your-project/index.md
@@ -4,7 +4,6 @@ tags: post
 date: 2022-08-16
 title: Finding .NET Transitive Dependencies and Tidying Up Your Project
 description: Clean up .NET transitive dependencies with Snitch tool - identify unnecessary references, reduce package conflicts, and optimize projects.
-featured_image: /images/archive/csharp/snitch/snitch-result.png
 ---
 
 Do you remember DLL Hell? 😈 Yes, me too.

--- a/src/archive/2023/why-i-always-avoid-internalsvisibleto-in-dotnet-unless/index.md
+++ b/src/archive/2023/why-i-always-avoid-internalsvisibleto-in-dotnet-unless/index.md
@@ -4,7 +4,6 @@ tags: post
 date: 2023-03-21
 title: Why I Always Avoid InternalsVisibleTo in .NET, Unless...
 description: Avoid InternalsVisibleTo in .NET testing - explore alternatives, maintain proper encapsulation, and design better APIs.
-featured_image:
 ---
 
 https://www.youtube.com/watch?v=O9GiOIw5XYc


### PR DESCRIPTION
Correcting a miss in the original audit, found while reviewing what was left to do.

## What was missed

The audit reported that no post carried an image field. It had grepped for `image`, `cover` and `thumbnail`. The field is `featured_image`, so the pattern never matched, and the fallback chain in #52 was built on the assumption that no post had its own image.

**62 of 127 posts have one.** Every share of those posts was falling back to the square headshot.

```
post            /archive/2023/dtos-the-good-the-bad-and-the-tradeoff/
featured_image  /images/archive/highlight/dtos-…-tradeoff.png   1080 x 500
og:image        /assets/headshot-1024x1024.png                  <- was
og:image        /images/archive/highlight/dtos-…-tradeoff.png   <- now
```

The shapes were already right. The 18 purpose-built highlight cards are 1080x500, and most of the rest are 1024x512. Both are close to the 2:1 that `summary_large_image` wants, where the square headshot gets cropped.

## The fix

`og:image`, `twitter:image` and the Article schema `image` now resolve `socialImage`, then `featured_image`, then the headshot.

It is a filter chain rather than an `if`, and that matters. Liquid treats an empty string as **truthy**, and one post carried an empty `featured_image`:

```
{% if '' %}          -> TRUTHY   would have set og:image to the site root
{{ '' | default: x }} -> x        correct
```

Also drops three unusable values: `snitch-result.png` and `continous-refactoring.png` point at files that are not in the repo, and the third is the empty one.

## Verified

```
og:image references          147
malformed                      0
missing from the build         0
og / twitter / schema disagree 0

posts with a /highlight/ card       18
posts using another in-post image   41
pages still using the headshot      68
```

## Not included

Course pages still use the headshot. Their images are all WebP, and platform support for WebP in `og:image` is less consistent than PNG. Worth a separate decision rather than folding in here.