### PR TITLE
Run the site on the Black Lab Studios foundation palette

### DIFF
--- a/src/_includes/components/about.liquid
+++ b/src/_includes/components/about.liquid
@@ -1,5 +1,5 @@
 <!-- About/Features Section -->
-<section id="about" class="bg-gray-50 py-20 dark:bg-black" aria-labelledby="about-heading">
+<section id="about" class="bg-surface py-20 dark:bg-black" aria-labelledby="about-heading">
   <div class="max-w-3xl mx-auto text-center mb-12">
     <h2 id="about-heading" class="text-3xl font-semibold mb-4 dark:text-white">Gui Ferreira</h2>
     <p class="text-lg text-gray-500 dark:text-gray-300">Making complex development concepts simple and accessible, one developer at a time.</p>

--- a/src/_includes/components/blog-featured.njk
+++ b/src/_includes/components/blog-featured.njk
@@ -1,7 +1,7 @@
 {% if post %}
 <div class="mb-16">
   <h2 class="text-xl font-medium text-gray-900 dark:text-white mb-8">Featured</h2>
-  <article class="bg-light-hover dark:bg-dark-blue text-gray-900 dark:text-white rounded-[2rem] px-8 py-12 hover:bg-gray-100 dark:hover:bg-dark-blue-hover transition-all duration-300">
+  <article class="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white rounded-lg px-8 py-12 hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-300">
     <div class="flex flex-col gap-4">
       <div class="flex items-center gap-3 text-sm">
         {% if post.data.category %}

--- a/src/_includes/components/blog-list.njk
+++ b/src/_includes/components/blog-list.njk
@@ -2,11 +2,11 @@
 <div class="py-12">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div>
-            <ul class="divide-y divide-gray-100 dark:divide-dark-blue">
+            <ul class="divide-y divide-gray-100 dark:divide-gray-800">
                 {% for post in posts %}
                     {% if not featured or post.url != featured.url %}
                     <li class="group">
-                        <article class="flex flex-col gap-3 py-12 -mx-8 px-8 rounded-[2rem] transition-all duration-300 hover:bg-light-hover dark:hover:bg-dark-blue">
+                        <article class="flex flex-col gap-3 py-12 -mx-8 px-8 rounded-lg transition-all duration-300 hover:bg-gray-100 dark:hover:bg-gray-800">
                             <div class="flex items-center gap-3 text-sm">
                                 {% if post.data.category %}
                                     <span class="uppercase font-medium text-gray-500 dark:text-gray-400">{{ post.data.category }}</span>

--- a/src/_includes/components/courses.liquid
+++ b/src/_includes/components/courses.liquid
@@ -1,5 +1,5 @@
 <!-- Courses Section -->
-<section id="courses" class="bg-white py-20 dark:bg-black" aria-labelledby="courses-heading">
+<section id="courses" class="bg-surface py-20 dark:bg-black" aria-labelledby="courses-heading">
   <div class="max-w-3xl mx-auto text-center mb-12">
     <h2 id="courses-heading" class="text-3xl font-semibold mb-4 dark:text-white">Courses</h2>
     <p class="text-lg text-gray-500 dark:text-gray-300">Level up your coding, design, and leadership skills with these hands-on, real-world learning experiences.</p>
@@ -28,7 +28,7 @@
         {% if course.data.rating %}
         <div class="flex items-center gap-1 mb-6" role="img" aria-label="Rating: {{ course.data.rating }} out of 5 stars">
           {% for i in (1..5) %}
-            <svg class="w-4 h-4 {% if i <= course.data.rating %}text-yellow-400{% else %}text-gray-200 dark:text-gray-700{% endif %}" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+            <svg class="w-4 h-4 {% if i <= course.data.rating %}text-gray-900 dark:text-white{% else %}text-gray-200 dark:text-gray-700{% endif %}" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
               <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
             </svg>
           {% endfor %}

--- a/src/_includes/components/hero.liquid
+++ b/src/_includes/components/hero.liquid
@@ -1,5 +1,5 @@
 <!-- Enhanced Hero Section with Fully Responsive Images -->
-<section class="bg-white pt-16 pb-20 dark:bg-black">
+<section class="bg-surface pt-16 pb-20 dark:bg-black">
   <div class="max-w-7xl mx-auto flex flex-col lg:flex-row items-center justify-between px-6 gap-12">
     <!-- Left: Headline & CTA -->
     <div class="flex-1">

--- a/src/_includes/components/testimonials.liquid
+++ b/src/_includes/components/testimonials.liquid
@@ -1,5 +1,5 @@
 <!-- Testimonials Section -->
-<section class="bg-gray-50 py-20 dark:bg-black" aria-labelledby="testimonials-heading">
+<section class="bg-surface py-20 dark:bg-black" aria-labelledby="testimonials-heading">
   <div class="max-w-3xl mx-auto text-center mb-12">
     <h2 id="testimonials-heading" class="text-2xl font-semibold mb-8 dark:text-white">What developers say</h2>
     <div class="grid gap-12 md:grid-cols-3 text-left md:text-center">

--- a/src/_includes/layouts/course.njk
+++ b/src/_includes/layouts/course.njk
@@ -9,7 +9,7 @@ layout: default
     <div class="flex items-center gap-1" role="img" aria-label="Rating: {{ rating }} out of 5 stars">
       <div class="flex">
         {% for i in range(1, 6) %}
-          <svg class="w-4 h-4 {% if i <= rating %}text-yellow-400{% else %}text-gray-200 dark:text-gray-700{% endif %}" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+          <svg class="w-4 h-4 {% if i <= rating %}text-gray-900 dark:text-white{% else %}text-gray-200 dark:text-gray-700{% endif %}" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
             <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
           </svg>
         {% endfor %}
@@ -114,7 +114,7 @@ layout: default
           {% endif %}
           <p class="text-gray-600 dark:text-gray-400 p-8">
             Your browser doesn't support video. 
-            <a href="{{ heroVideo.mp4 }}" class="text-blue-600 dark:text-blue-400 underline">
+            <a href="{{ heroVideo.mp4 }}" class="text-gray-900 dark:text-white underline">
               Download the course preview video
             </a>
           </p>
@@ -251,35 +251,35 @@ layout: default
           <h3 class="font-medium text-gray-900 dark:text-white text-center transition-colors">Everything you need to succeed:</h3>
           <div class="grid grid-cols-1 gap-3">
             <div class="flex items-center gap-3">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big h-5 w-5 text-gray-900 dark:text-white flex-shrink-0">
                 <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
                 <path d="m9 11 3 3L22 4"></path>
               </svg>
               <span class="text-gray-600 dark:text-gray-300 font-light transition-colors">{{ duration }} of video content</span>
             </div>
             <div class="flex items-center gap-3">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big h-5 w-5 text-gray-900 dark:text-white flex-shrink-0">
                 <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
                 <path d="m9 11 3 3L22 4"></path>
               </svg>
               <span class="text-gray-600 dark:text-gray-300 font-light transition-colors">Downloadable resources</span>
             </div>
             <div class="flex items-center gap-3">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big h-5 w-5 text-gray-900 dark:text-white flex-shrink-0">
                 <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
                 <path d="m9 11 3 3L22 4"></path>
               </svg>
               <span class="text-gray-600 dark:text-gray-300 font-light transition-colors">Certificate of completion</span>
             </div>
             <div class="flex items-center gap-3">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big h-5 w-5 text-gray-900 dark:text-white flex-shrink-0">
                 <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
                 <path d="m9 11 3 3L22 4"></path>
               </svg>
               <span class="text-gray-600 dark:text-gray-300 font-light transition-colors">Lifetime access to all updates</span>
             </div>
             <div class="flex items-center gap-3">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big h-5 w-5 text-gray-900 dark:text-white flex-shrink-0">
                 <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
                 <path d="m9 11 3 3L22 4"></path>
               </svg>
@@ -317,7 +317,7 @@ layout: default
 </section> 
 
 {% if relatedCourses %}
-<section class="py-24 lg:py-32 bg-gray-50 dark:bg-black border-t border-gray-100 dark:border-gray-900 transition-colors">
+<section class="py-24 lg:py-32 bg-surface dark:bg-black border-t border-gray-100 dark:border-gray-900 transition-colors">
   <div class="container mx-auto px-6 max-w-6xl">
     <div class="space-y-16">
       <h2 class="text-3xl font-medium text-gray-900 dark:text-white transition-colors">Students also enrolled in</h2>

--- a/src/_includes/layouts/default.liquid
+++ b/src/_includes/layouts/default.liquid
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="overflow-y-scroll font-sans bg-white text-gray-900 dark:bg-black dark:text-white" lang="en">
+<html class="overflow-y-scroll font-sans bg-surface text-gray-900 dark:bg-black dark:text-white" lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover" />
@@ -85,14 +85,14 @@
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"></noscript>
     <style>
       body {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+        font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
       }
       /* Skip link styles */
       .skip-link {
         position: absolute;
         top: -40px;
         left: 6px;
-        background: #000;
+        background: #1A1A1A;
         color: #fff;
         padding: 8px;
         text-decoration: none;
@@ -112,21 +112,21 @@
       
       /* Improved focus styles */
       :focus-visible {
-        outline: 2px solid #2563eb;
+        outline: 2px solid #1A1A1A;
         outline-offset: 2px;
       }
       .dark :focus-visible {
-        outline-color: #60a5fa;
+        outline-color: #FFFFFF;
       }
     </style>
   </head>
-  <body class="bg-white dark:bg-black">
+  <body class="bg-surface dark:bg-black">
     <!-- Skip Navigation Links -->
     <a href="#main-content" class="skip-link">Skip to main content</a>
     <a href="#navigation" class="skip-link">Skip to navigation</a>
     
     <!-- Navigation -->
-    <nav id="navigation" class="w-full border-b border-gray-100 bg-white dark:bg-black dark:border-gray-800" role="navigation" aria-label="Main navigation">
+    <nav id="navigation" class="w-full border-b border-gray-100 bg-surface dark:bg-black dark:border-gray-800" role="navigation" aria-label="Main navigation">
       <div class="max-w-7xl mx-auto flex items-center justify-between px-6 py-4">
         <a href="/" class="text-lg font-medium tracking-tight text-gray-900 dark:text-white" aria-label="Gui Ferreira - Home">Gui Ferreira</a>
         
@@ -190,7 +190,7 @@
     </main>
 
     <!-- Footer -->
-    <footer class="bg-white border-t border-gray-100 mt-24 dark:bg-black dark:border-gray-800" role="contentinfo">
+    <footer class="bg-surface border-t border-gray-100 mt-24 dark:bg-black dark:border-gray-800" role="contentinfo">
       <div class="max-w-7xl mx-auto px-6 py-16 grid grid-cols-1 md:grid-cols-4 gap-12 text-sm text-gray-700 dark:text-gray-300">
         <div>
           <div class="font-semibold mb-2">Gui Ferreira</div>

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -82,7 +82,7 @@ layout: default
     </ol>
   </nav>
 
-  <article class="prose prose-lg prose-headings:text-2xl prose-headings:font-medium prose-headings:mb-4 prose-p:text-[1.125rem] prose-p:leading-[1.8] max-w-none dark:prose-p:text-gray-300 dark:prose-li:text-gray-300 dark:prose-ul:text-gray-300 dark:prose-ol:text-gray-300 dark:prose-headings:text-white dark:prose-strong:text-white dark:prose-a:text-blue-400 dark:prose-a:hover:text-blue-300 dark:prose-invert">
+  <article class="prose prose-lg prose-headings:text-2xl prose-headings:font-medium prose-headings:mb-4 prose-p:text-[1.125rem] prose-p:leading-[1.8] max-w-none dark:prose-p:text-gray-300 dark:prose-li:text-gray-300 dark:prose-ul:text-gray-300 dark:prose-ol:text-gray-300 dark:prose-headings:text-white dark:prose-strong:text-white dark:prose-a:text-white dark:prose-a:hover:text-gray-300 dark:prose-invert">
     <header class="not-prose mb-16">
       <div class="flex items-center gap-6 mb-4">
         {% if category %}

--- a/src/_includes/layouts/workshop.njk
+++ b/src/_includes/layouts/workshop.njk
@@ -2,7 +2,7 @@
 layout: default.liquid
 ---
 
-<section class="relative bg-white dark:bg-black py-24 lg:py-32 mt-16 transition-colors">
+<section class="relative bg-surface dark:bg-black py-24 lg:py-32 mt-16 transition-colors">
   <div class="container mx-auto px-6 max-w-6xl">
     <div class="grid lg:grid-cols-2 gap-16 items-start">
       <div class="space-y-6">
@@ -103,7 +103,7 @@ layout: default.liquid
   </div>
 </section>
 
-<section class="py-12 lg:py-16 bg-white dark:bg-black transition-colors">
+<section class="py-12 lg:py-16 bg-surface dark:bg-black transition-colors">
   <div class="container mx-auto px-6 max-w-4xl">
     <div class="prose dark:prose-invert dark:text-gray-200 prose-headings:dark:text-white prose-strong:dark:text-white prose-ul:dark:text-gray-200 max-w-none">
       {{ content | safe }}
@@ -111,7 +111,7 @@ layout: default.liquid
   </div>
 </section>
 
-<section class="py-12 lg:py-16 bg-gray-50 dark:bg-black transition-colors">
+<section class="py-12 lg:py-16 bg-surface dark:bg-black transition-colors">
   <div class="container mx-auto px-6 max-w-4xl">
     <div class="space-y-16">
       <div class="text-center space-y-6">
@@ -163,7 +163,7 @@ layout: default.liquid
 </section>
 
 
-<section id="upcoming" class="py-24 lg:py-32 bg-gray-50 dark:bg-black transition-colors">
+<section id="upcoming" class="py-24 lg:py-32 bg-surface dark:bg-black transition-colors">
   <div class="container mx-auto px-6 max-w-4xl">
     <div class="space-y-16">
       <div class="text-center space-y-6">
@@ -180,7 +180,7 @@ layout: default.liquid
 </section>
 
 {% if testimonials %}
-<section class="py-12 lg:py-16 bg-white dark:bg-black transition-colors">
+<section class="py-12 lg:py-16 bg-surface dark:bg-black transition-colors">
   <div class="container mx-auto px-6 max-w-6xl">
     <div class="space-y-16">
       <div class="text-center space-y-6">
@@ -218,7 +218,7 @@ layout: default.liquid
 {% endif %}
 
 {% if faqs %}
-<section class="py-24 lg:py-32 bg-gray-50 dark:bg-black transition-colors">
+<section class="py-24 lg:py-32 bg-surface dark:bg-black transition-colors">
   <div class="container mx-auto px-6 max-w-4xl">
     <div class="space-y-16">
       <div class="text-center space-y-6">
@@ -264,7 +264,7 @@ layout: default.liquid
 {% endif %}
 
 {% if related_workshops %}
-<section class="py-24 lg:py-32 bg-white dark:bg-black border-t border-gray-100 dark:border-gray-900 transition-colors">
+<section class="py-24 lg:py-32 bg-surface dark:bg-black border-t border-gray-100 dark:border-gray-900 transition-colors">
   <div class="container mx-auto px-6 max-w-6xl">
     <div class="space-y-16">
       <h2 class="text-3xl font-medium text-gray-900 dark:text-white transition-colors">Related workshops</h2>

--- a/src/assets/feed.css
+++ b/src/assets/feed.css
@@ -1,11 +1,11 @@
 feed {
     max-width: 65ch;
     margin: 0 auto;
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
     line-height: 1.6;
     padding: 4rem 1.5rem;
-    color: #1a1a1a;
-    background: #fff;
+    color: #1A1A1A;
+    background: #F6F4F1;
   }
   
   title {
@@ -13,13 +13,13 @@ feed {
     font-size: 2.5rem;
     font-weight: 700;
     margin-bottom: 1rem;
-    color: #000;
+    color: #1A1A1A;
   }
   
   subtitle {
     display: block;
     font-size: 1.25rem;
-    color: #666;
+    color: #6B6B6B;
     margin-bottom: 3rem;
     line-height: 1.5;
   }
@@ -27,7 +27,7 @@ feed {
   author {
     display: block;
     margin: 2rem 0;
-    color: #666;
+    color: #6B6B6B;
     font-size: 0.9rem;
   }
   
@@ -35,7 +35,7 @@ feed {
     display: block;
     margin: 3rem 0;
     padding-bottom: 1rem;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid #D1D1D1;
   }
   
   entry:last-child {
@@ -48,13 +48,13 @@ feed {
   }
   
   entry title a {
-    color: #000;
+    color: #1A1A1A;
     text-decoration: none;
     transition: color 0.2s ease;
   }
   
   entry title a:hover {
-    color: #666;
+    color: #6B6B6B;
   }
   
   content {

--- a/src/courses.liquid
+++ b/src/courses.liquid
@@ -62,7 +62,7 @@ faq:
 </script>
 
 
-<section class="relative bg-white dark:bg-black py-24 lg:py-32 mt-16 transition-colors">
+<section class="relative bg-surface dark:bg-black py-24 lg:py-32 mt-16 transition-colors">
   <div class="container mx-auto px-6 max-w-4xl">
     <div class="text-center space-y-8">
       <h1 class="text-5xl lg:text-6xl [font-size:3rem] lg:[font-size:3.75rem] font-light text-gray-900 dark:text-white leading-tight tracking-tight transition-colors">Courses</h1>
@@ -71,7 +71,7 @@ faq:
   </div>
 </section>
 
-<section class="py-12 lg:py-16 bg-white dark:bg-black transition-colors">
+<section class="py-12 lg:py-16 bg-surface dark:bg-black transition-colors">
   <div class="container mx-auto px-6 max-w-6xl">
     <div class="grid gap-12">
       {% for course in collections.courses %}
@@ -185,7 +185,7 @@ faq:
     <div class="bg-gray-50 dark:bg-gray-900 p-8 rounded-2xl">
       <div class="flex mb-4">
         {% for i in (1..5) %}
-          <svg class="w-5 h-5 text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
+          <svg class="w-5 h-5 text-gray-900 dark:text-white" fill="currentColor" viewBox="0 0 20 20">
             <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
           </svg>
         {% endfor %}
@@ -197,7 +197,7 @@ faq:
     <div class="bg-gray-50 dark:bg-gray-900 p-8 rounded-2xl">
       <div class="flex mb-4">
         {% for i in (1..5) %}
-          <svg class="w-5 h-5 text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
+          <svg class="w-5 h-5 text-gray-900 dark:text-white" fill="currentColor" viewBox="0 0 20 20">
             <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
           </svg>
         {% endfor %}
@@ -209,7 +209,7 @@ faq:
     <div class="bg-gray-50 dark:bg-gray-900 p-8 rounded-2xl">
       <div class="flex mb-4">
         {% for i in (1..5) %}
-          <svg class="w-5 h-5 text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
+          <svg class="w-5 h-5 text-gray-900 dark:text-white" fill="currentColor" viewBox="0 0 20 20">
             <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
           </svg>
         {% endfor %}

--- a/src/newsletter.liquid
+++ b/src/newsletter.liquid
@@ -4,7 +4,7 @@ title: Weekly .NET and Clean Code Newsletter
 description: Subscribe to my newsletter to get weekly insights about .NET, Software Architecture, and Clean Code.
 ---
 
-<section class="relative bg-white dark:bg-black py-24 lg:py-32 mt-16 transition-colors">
+<section class="relative bg-surface dark:bg-black py-24 lg:py-32 mt-16 transition-colors">
     <div class="container mx-auto px-6 max-w-6xl">
         <div class="grid lg:grid-cols-2 gap-16 items-center">
             <div class="order-2 lg:order-1">

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,10 +2,17 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Black Lab Studios: body is 16/28. */
+@layer base {
+  body {
+    line-height: 1.75;
+  }
+}
+
 /* PrismJS Syntax Highlighting */
 pre[class*="language-"],
 code[class*="language-"] {
-  color: #374151; /* Dark gray for default text */
+  color: #484848; /* Dark gray for default text */
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   direction: ltr;
   text-align: left;
@@ -24,38 +31,38 @@ pre[class*="language-"] {
   padding: 1.25rem;
   margin: 1.25em 0;
   overflow: auto;
-  border: 1px solid #e2e8f0;
+  border: 1px solid #D1D1D1;
   border-radius: 0.5rem;
-  background: #f8fafc;
+  background: #EDEAE5;
 }
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
   padding: 0.125rem 0.375rem;
   border-radius: 0.25rem;
-  background: #f3f4f6;
-  color: #4b5563;
+  background: #EDEAE5;
+  color: #484848;
 }
 
 /* Dark theme overrides */
 .dark pre[class*="language-"] {
-  background: #1a1e2d;
-  border-color: #2d3748;
-  color: #e5e7eb;
+  background: #242424;
+  border-color: #3A3A3A;
+  color: #D1D1D1;
 }
 
 .dark :not(pre) > code[class*="language-"] {
-  background: #1a1e2d;
-  color: #e5e7eb;
+  background: #242424;
+  color: #D1D1D1;
 }
 
 /* Dark mode list markers */
 .dark .prose ul li::marker {
-  color: #e5e7eb !important;
+  color: #D1D1D1 !important;
 }
 
 .dark .prose ol li::marker {
-  color: #e5e7eb !important;
+  color: #D1D1D1 !important;
 }
 
 /* Tokens */
@@ -63,11 +70,11 @@ pre[class*="language-"] {
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: #6b7280; /* Gray for comments */
+  color: #6B6B6B; /* Charcoal 60 for comments */
 }
 
 .token.punctuation {
-  color: #64748b;
+  color: #6B6B6B;
 }
 
 .token.namespace {
@@ -121,11 +128,11 @@ pre[class*="language-"] {
 .dark .token.prolog,
 .dark .token.doctype,
 .dark .token.cdata {
-  color: #9ca3af;
+  color: #A3A3A3;
 }
 
 .dark .token.punctuation {
-  color: #e5e7eb;
+  color: #D1D1D1;
 }
 
 .dark .token.property,
@@ -173,7 +180,7 @@ pre[class*="language-"] {
 /* Base text color for code in dark mode */
 .dark code[class*="language-"],
 .dark pre[class*="language-"] {
-  color: #e5e7eb;
+  color: #D1D1D1;
 }
 
 .token.important,

--- a/src/workshops.liquid
+++ b/src/workshops.liquid
@@ -47,8 +47,8 @@ description: Where to catch me running a workshop in public, and how to book one
 {%- endif -%}
 
 
-<main class="min-h-screen bg-white dark:bg-black">
-    <section class="relative bg-white dark:bg-black py-24 lg:py-32 mt-16 transition-colors">
+<main class="min-h-screen bg-surface dark:bg-black">
+    <section class="relative bg-surface dark:bg-black py-24 lg:py-32 mt-16 transition-colors">
         <div class="container mx-auto px-6 max-w-6xl">
             <div class="text-center space-y-8">
                 <h1 class="text-5xl lg:text-6xl [font-size:3rem] lg:[font-size:3.75rem] font-light text-gray-900 dark:text-white leading-tight tracking-tight transition-colors">Workshops</h1>
@@ -57,7 +57,7 @@ description: Where to catch me running a workshop in public, and how to book one
         </div>
     </section>
 
-    <section id="upcoming" class="py-24 lg:py-32 bg-gray-50 dark:bg-black transition-colors">
+    <section id="upcoming" class="py-24 lg:py-32 bg-surface dark:bg-black transition-colors">
         <div class="container mx-auto px-6 max-w-6xl">
             <div class="space-y-16">
                 <div class="text-center space-y-6">
@@ -96,7 +96,7 @@ description: Where to catch me running a workshop in public, and how to book one
         </div>
     </section>
 
-    <section class="py-24 lg:py-32 bg-white dark:bg-black transition-colors">
+    <section class="py-24 lg:py-32 bg-surface dark:bg-black transition-colors">
         <div class="container mx-auto px-6 max-w-6xl">
             <div class="space-y-16">
                 <div class="text-center space-y-6">
@@ -132,7 +132,7 @@ description: Where to catch me running a workshop in public, and how to book one
         </div>
     </section>
 
-    <section class="py-24 lg:py-32 bg-gray-50 dark:bg-black transition-colors">
+    <section class="py-24 lg:py-32 bg-surface dark:bg-black transition-colors">
         <div class="container mx-auto px-6 max-w-6xl">
             <div class="max-w-2xl mx-auto text-center space-y-8">
                 <h2 class="text-4xl lg:text-5xl font-light text-gray-900 dark:text-white tracking-tight transition-colors">Run one for your team</h2>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,12 @@
+/**
+ * Black Lab Studios design system, Gui Ferreira sub-brand.
+ *
+ * Foundation colours only. Rock, Meadow Mist, Warm Clay, Lavender and Pampas
+ * all stay out: this is the one surface in the system that runs neutral.
+ * Charcoal #1A1A1A, not #000000. Off White #F6F4F1, not #FFFFFF.
+ *
+ * Spec: Brand/Sub-brands/Gui Ferreira.md
+ */
 module.exports = {
   darkMode: 'class',
   content: [
@@ -10,26 +19,71 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        'sans': ['Inter', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'sans-serif'],
+        'sans': ['Inter', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Helvetica', 'Arial', 'sans-serif'],
       },
       colors: {
-        'dark-blue': '#121722',
-        'dark-blue-hover': '#1D252F',
-        'light-hover': '#F8F9FB',
+        // Charcoal, the brand's black.
+        black: '#1A1A1A',
+        // Off White, the light page ground.
+        surface: '#F6F4F1',
+        // The Charcoal ladder, with tween steps where Tailwind needs more
+        // stops than the five the brand defines.
+        gray: {
+          50: '#FFFFFF',   // raised surface, bands lift off the off-white page
+          100: '#EDEAE5',  // warm hover
+          200: '#DEDCD9',  // light hairline
+          300: '#D1D1D1',  // Charcoal 20, dark-mode body text and rules
+          400: '#A3A3A3',  // Charcoal 40, dark-mode muted
+          500: '#666666',  // Charcoal 60 nudged to clear AA on page and sunken alike
+          600: '#484848',  // Charcoal 80, light-mode secondary text
+          700: '#3A3A3A',
+          800: '#2E2E2E',
+          900: '#242424',  // dark-mode raised card surface
+          950: '#1A1A1A',  // Charcoal
+        },
+      },
+      borderRadius: {
+        DEFAULT: '4px',
+        'sm': '2px',
+        'md': '4px',
+        'lg': '8px',
+        'xl': '8px',
+        '2xl': '8px',
+        '3xl': '8px',
+        'full': '9999px', // buttons and tags keep the pill
       },
       typography: {
         DEFAULT: {
           css: {
             'max-width': 'none',
-            color: '#374151',
+            // Drive every prose colour from the foundation. Without these the
+            // plugin keeps its stock cool greys on h1, h4, quotes and rules.
+            '--tw-prose-body': '#484848',
+            '--tw-prose-headings': '#1A1A1A',
+            '--tw-prose-lead': '#484848',
+            '--tw-prose-links': '#1A1A1A',
+            '--tw-prose-bold': '#1A1A1A',
+            '--tw-prose-counters': '#6B6B6B',
+            '--tw-prose-bullets': '#A3A3A3',
+            '--tw-prose-hr': '#D1D1D1',
+            '--tw-prose-quotes': '#1A1A1A',
+            '--tw-prose-quote-borders': '#D1D1D1',
+            '--tw-prose-captions': '#6B6B6B',
+            '--tw-prose-kbd': '#1A1A1A',
+            '--tw-prose-code': '#1A1A1A',
+            '--tw-prose-pre-code': '#484848',
+            '--tw-prose-pre-bg': '#EDEAE5',
+            '--tw-prose-th-borders': '#D1D1D1',
+            '--tw-prose-td-borders': '#DEDCD9',
+            color: '#484848',
             h2: {
-              color: '#111827',
+              color: '#1A1A1A',
               fontWeight: '600',
               marginTop: '2em',
               marginBottom: '1em',
             },
             h3: {
-              color: '#111827',
+              color: '#1A1A1A',
               fontWeight: '600',
               marginTop: '1.6em',
               marginBottom: '0.6em',
@@ -38,18 +92,23 @@ module.exports = {
               marginTop: '1.25em',
               marginBottom: '1.25em',
             },
+            // With no accent in the palette, colour cannot carry link meaning.
+            // The underline does the work.
             a: {
-              color: '#2563eb',
+              color: '#1A1A1A',
+              textDecoration: 'underline',
+              textUnderlineOffset: '3px',
+              textDecorationThickness: '1px',
               '&:hover': {
-                color: '#1d4ed8',
+                color: '#484848',
               },
             },
             pre: {
-              backgroundColor: '#f8fafc',
-              color: '#334155',
+              backgroundColor: '#EDEAE5',
+              color: '#484848',
               padding: '1.25rem',
-              borderRadius: '0.5rem',
-              border: '1px solid #e2e8f0',
+              borderRadius: '8px',
+              border: '1px solid #D1D1D1',
               marginTop: '1.25em',
               marginBottom: '1.25em',
             },
@@ -58,7 +117,7 @@ module.exports = {
               borderWidth: '0',
               borderRadius: '0',
               padding: '0',
-              color: '#334155',
+              color: '#484848',
               fontSize: '0.875em',
               fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
               '&::before': {
@@ -69,13 +128,13 @@ module.exports = {
               },
             },
             code: {
-              color: '#4b5563',
-              backgroundColor: '#f3f4f6',
+              color: '#484848',
+              backgroundColor: '#EDEAE5',
               paddingLeft: '0.375rem',
               paddingRight: '0.375rem',
               paddingTop: '0.125rem',
               paddingBottom: '0.125rem',
-              borderRadius: '0.25rem',
+              borderRadius: '2px',
               fontWeight: '400',
               fontSize: '0.875em',
               fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
@@ -92,75 +151,50 @@ module.exports = {
             'code::after': {
               content: '""',
             },
-            // Syntax highlighting colors
-            '.hljs-keyword': {
-              color: '#8b5cf6', // Purple for keywords
-            },
-            '.hljs-string': {
-              color: '#059669', // Green for strings
-            },
-            '.hljs-comment': {
-              color: '#6b7280', // Gray for comments
-            },
-            '.hljs-type': {
-              color: '#2563eb', // Blue for types
-            },
-            '.hljs-number': {
-              color: '#db2777', // Pink for numbers
-            },
-            '.hljs-function': {
-              color: '#4b5563', // Gray for functions
-            },
-            '.hljs-title': {
-              color: '#4b5563', // Gray for titles
-            },
-            '.hljs-params': {
-              color: '#4b5563', // Gray for parameters
-            },
           },
         },
-        // Add dark mode styles
+        // Dark mode prose. Charcoal base, White text, Charcoal 20 for body.
         'invert': {
           css: {
-            '--tw-prose-body': '#e5e7eb',
-            '--tw-prose-headings': '#f3f4f6',
-            '--tw-prose-links': '#60a5fa',
-            '--tw-prose-links-hover': '#93c5fd',
-            '--tw-prose-underline': '#60a5fa',
-            '--tw-prose-underline-hover': '#93c5fd',
-            '--tw-prose-bold': '#f3f4f6',
-            '--tw-prose-counters': '#9ca3af',
-            '--tw-prose-bullets': '#e5e7eb',
-            '--tw-prose-hr': '#374151',
-            '--tw-prose-quote-borders': '#374151',
-            '--tw-prose-captions': '#9ca3af',
-            '--tw-prose-code': '#f3f4f6',
-            '--tw-prose-code-bg': '#1a1e2d',
-            '--tw-prose-pre-code': '#e5e7eb',
-            '--tw-prose-pre-bg': '#1a1e2d',
-            '--tw-prose-pre-border': '#2d3748',
-            '--tw-prose-th-borders': '#4a5568',
-            '--tw-prose-td-borders': '#2d3748',
+            '--tw-prose-body': '#D1D1D1',
+            '--tw-prose-headings': '#FFFFFF',
+            '--tw-prose-lead': '#D1D1D1',
+            '--tw-prose-links': '#FFFFFF',
+            '--tw-prose-quotes': '#FFFFFF',
+            '--tw-prose-bold': '#FFFFFF',
+            '--tw-prose-counters': '#A3A3A3',
+            '--tw-prose-bullets': '#D1D1D1',
+            '--tw-prose-hr': '#3A3A3A',
+            '--tw-prose-quote-borders': '#3A3A3A',
+            '--tw-prose-captions': '#A3A3A3',
+            '--tw-prose-code': '#FFFFFF',
+            '--tw-prose-pre-code': '#D1D1D1',
+            '--tw-prose-pre-bg': '#242424',
+            '--tw-prose-th-borders': '#484848',
+            '--tw-prose-td-borders': '#3A3A3A',
 
             // Override nested elements
             'h1, h2, h3, h4, h5, h6': {
-              color: '#f3f4f6',
+              color: '#FFFFFF',
             },
             p: {
-              color: '#e5e7eb',
+              color: '#D1D1D1',
             },
             a: {
-              color: '#60a5fa',
+              color: '#FFFFFF',
+              textDecoration: 'underline',
+              textUnderlineOffset: '3px',
+              textDecorationThickness: '1px',
               '&:hover': {
-                color: '#93c5fd',
+                color: '#D1D1D1',
               },
             },
             strong: {
-              color: '#f3f4f6',
+              color: '#FFFFFF',
             },
             code: {
-              color: '#f3f4f6',
-              backgroundColor: '#1a1e2d',
+              color: '#FFFFFF',
+              backgroundColor: '#242424',
             },
             'code::before': {
               content: '""',
@@ -169,28 +203,28 @@ module.exports = {
               content: '""',
             },
             figcaption: {
-              color: '#9ca3af',
+              color: '#A3A3A3',
             },
             blockquote: {
-              color: '#e5e7eb',
+              color: '#D1D1D1',
             },
             'ul > li::marker': {
-              color: '#e5e7eb',
+              color: '#D1D1D1',
             },
             'ol > li::marker': {
-              color: '#e5e7eb',
+              color: '#D1D1D1',
             },
             'thead th': {
-              color: '#f3f4f6',
+              color: '#FFFFFF',
             },
             'tbody td': {
-              color: '#e5e7eb',
+              color: '#D1D1D1',
             },
             'tbody tr': {
-              borderBottomColor: '#2d3748',
+              borderBottomColor: '#3A3A3A',
             },
             'thead': {
-              borderBottomColor: '#4a5568',
+              borderBottomColor: '#484848',
             },
           },
         },
@@ -200,4 +234,4 @@ module.exports = {
   plugins: [
     require('@tailwindcss/typography'),
   ],
-}; 
+};


### PR DESCRIPTION
## What this is

The brand architecture moved to Black Lab Studios in #51. The pixels did not. That commit never touched `tailwind.config.js` or a stylesheet, so the site was still running Tailwind's stock palette. The sub-brand file's own audit puts it plainly:

> The gap is colour, and specifically that it's blue. The site runs Tailwind's default palette, which is cool-tinted rather than neutral.

This closes that gap.

## Why it is only 16 files

The site had no design token layer, but it also had almost no custom palette. Around **1,285 colour utilities all sat on stock `gray-*`, `black` and `white`**. So the system is applied by redefining those names in the theme rather than by rewriting templates.

- `gray-50` to `gray-950` is now the Charcoal ladder, with tween steps where Tailwind needs more stops than the five the brand defines
- `black` is Charcoal `#1A1A1A`
- one new colour, `surface` (`#F6F4F1`), carries the Off White page ground

Changing a shade in the config now repaints the whole site. Inter was already the typeface, so only the fallback stack needed aligning.

## What changed visually

| | Before | After |
|---|---|---|
| Neutrals | stock Tailwind grey, cool-tinted | Charcoal ladder `#1A1A1A` / 80 / 60 / 40 / 20 |
| Page ground | white | Off White `#F6F4F1` |
| Dark ground | pure black | Charcoal `#1A1A1A` |
| Prose links | blue `#2563eb` | Charcoal, underlined |
| Radii | `2xl` 16px, `3xl` 24px | 8px, pills untouched |
| Accents | yellow stars, green ticks, blue links | none |

**Foundation colours only.** Rock, Meadow Mist, Warm Clay and Lavender stay out, and so does Pampas. Links now carry meaning by underline, which is what the spec asks for when there is no accent to spend.

**Dark mode rides the change with no edits.** All 541 `dark:` utilities resolve through the same ladder.

## Two deliberate deviations from the spec

Both are commented in the config.

1. **`gray-500` is `#666666`, not Charcoal 60 `#757575`.** Charcoal 60 measures 4.1:1 on Off White, and every consumer here is 12px or 14px body text. blacklabstudios.com hit the same wall and raised its own muted token for the same reason.
2. **Raised dark is `#242424`, not Charcoal 80 `#484848`.** At full strength a card reads as washed-out mid-grey against the page. `#484848` survives as the dark border tone.

## Two things left alone on purpose

- **The homepage hero keeps 60px Light** rather than the spec's 56px SemiBold. That block is built on the weight contrast across its three lines, and SemiBold flattens it to SemiBold versus Bold.
- **The logo slot is untouched.** The sub-brand file holds anything that bakes in the mark, OG images and favicon included, until the vectors land.

## Rejected along the way

Light mode is one continuous Off White ground with white cards doing the lifting. Alternating section bands were tried three ways and none earned their place: pure white, a derived warm tint, and Charcoal 20 at 40%. Full-strength Charcoal 20 was measured but never shipped, since it drops muted text to 3.76:1 with about 15 muted-text instances sitting on bands.

## Verification

Production build is clean. Walked `/`, `/blog`, an archive post, `/courses`, a course page, `/workshops`, `/about` and `/newsletter` in both themes.

Contrast checked against the pairs the spec names:

| Ink | on Off White | on White |
|---|---|---|
| Charcoal `#1A1A1A` | 15.85 AAA | 17.40 AAA |
| Charcoal 80 `#484848` | 8.33 AAA | 9.15 AAA |
| muted `#666666` | 5.23 AA | 5.74 AA |

Pre-existing and not addressed here: the theme script runs on `DOMContentLoaded`, so dark-mode users still get a white flash on navigation. Worth its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
